### PR TITLE
fix: remove bar from verify API request

### DIFF
--- a/pkg/server/verify_test.go
+++ b/pkg/server/verify_test.go
@@ -16,11 +16,9 @@ import (
 )
 
 var (
-	obj = func(image string) map[string]any {
-		return map[string]any{
-			"imageReferences": map[string]string{
-				"bar": image,
-			},
+	obj = func(image string) map[string]string {
+		return map[string]string{
+			"imageReference": image,
 		}
 	}
 

--- a/policies/critical.yaml
+++ b/policies/critical.yaml
@@ -10,7 +10,7 @@ spec:
   # images is the path to the images in the JSON object
   images:
     - name: imagerefs
-      expression: "[object.imageReferences.bar]"
+      expression: "[object.imageReference]"
   attestors:
     - name: notary
       notary:

--- a/policies/high.yaml
+++ b/policies/high.yaml
@@ -9,7 +9,7 @@ spec:
     - glob: ghcr.io/*
   images:
     - name: imagerefs
-      expression: "[object.imageReferences.bar]"
+      expression: "[object.imageReference]"
   attestors:
     - name: notary
       notary:

--- a/policies/signed.json
+++ b/policies/signed.json
@@ -1,5 +1,3 @@
 {
-  "imageReferences":{
-    "bar": "ghcr.io/kyverno/test-verify-image:signed"
-  }
+  "imageReference": "ghcr.io/kyverno/test-verify-image:signed"
 }

--- a/policies/unsigned.json
+++ b/policies/unsigned.json
@@ -1,5 +1,3 @@
 {
-  "imageReferences": {
-    "bar": "ghcr.io/kyverno/test-verify-image:unsigned"
-  }
+  "imageReference": "ghcr.io/kyverno/test-verify-image:unsigned"
 }


### PR DESCRIPTION
## Explanation

We previously made the API request overly complex for no apparent reason. This PR simplifies it from 

```json
{ "imageReferences": { "bar": "<image_here>" } }
```

to

```json
{ "imageReference": "<image_here>" }
```

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Fixes https://github.com/nirmata/demo-image-compliance/issues/23


## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

The CI will probably fail with nil pointer exception out of the box since we need to upload new images for `ghcr.io/nirmata/image-compliance-policies:block-critical-vulnerabilities|block-high-and-critical-vulnerabilities`